### PR TITLE
Drop invalid "support" references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-Crunch\FastCGI [![Build Status](https://secure.travis-ci.org/KingCrunch/FastCGI.png)](http://travis-ci.org/KingCrunch/FastCGI)
-===
-FastCGI client library
+Fork of [https://github.com/CrunchPHP/fastcgi]
 
-* [Documentation at readthedocs.org](http://crunchfastcgi.readthedocs.org/en/latest/)
-* [List of available packages at packagist.org](http://packagist.org/packages/crunch/fastcgi)
+FastCGI client library
 
 
 Allows to access a FastCGI-server directly from PHP.
@@ -53,8 +50,6 @@ Requirements
 Contributors
 ============
 See CONTRIBUTING.md for details on how to contribute.
-
-* Sebastian "KingCrunch" Krebs <krebs.seb@gmail.com> -- http://www.kingcrunch.de/ (german)
 
 License
 =======

--- a/composer.json
+++ b/composer.json
@@ -3,26 +3,13 @@
     "description": "fastcgi client",
     "type": "library",
     "keywords": ["FastCGI"],
-    "homepage": "http://crunchfastcgi.readthedocs.org/en/latest/",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Sebastian Krebs",
-            "email": "krebs.seb@gmail.com",
-            "homepage": "http://www.kingcrunch.de",
-            "role": "Maintainer"
-        }
-    ],
     "require": {
         "php": ">=5.3.0"
     },
     "require-dev": {
         "phake/phake": "~2.0@dev",
         "appserver-io/build" : "~1.0"
-    },
-    "support": {
-        "email": "krebs.seb@gmail.com",
-        "issues": "https://github.com/KingCrunch/FastCGI/issues"
     },
     "autoload": {
         "psr-4": { "Crunch\\FastCGI\\": ["src", "tests"]  }


### PR DESCRIPTION
Hi,

I want to clarify, that I don't give any support for this fork. I somehow accepted, that you decided to maintain your fork independent from the upstream without contributing back. That's fine and afaik legitimate regarding the license. In the meantime upstream became completely incompatible anyway, so there is neither something I can do for you, nor that you can do for me.

However, remember that the copyright of the code I wrote and that is still visible is _not_ affected. 

Thanks :)
